### PR TITLE
Change node version to 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"typescript": "4"
 	},
 	"engines": {
-		"node": ">=16.0.0"
+		"node": ">=12.0.0"
 	},
 	"files": [
 		"/lib",


### PR DESCRIPTION
On ubuntu latest version is 12 and this plugin woroks in lower node version so I dont see why not